### PR TITLE
feat: add Momentum ambient briefing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact SHA
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Test shipped extension behavior
+        run: npm test -- --runInBand

--- a/manifest.json
+++ b/manifest.json
@@ -7,11 +7,13 @@
   
   "permissions": [
     "storage",
-    "bookmarks"
+    "bookmarks",
+    "nativeMessaging"
   ],
   
   "host_permissions": [
-    "https://www.google.com/"
+    "https://www.google.com/",
+    "http://127.0.0.1/*"
   ],
   
   "chrome_url_overrides": {
@@ -46,7 +48,7 @@
   },
   
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src https://www.google.com/;"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src https://www.google.com/ http://127.0.0.1:*;"
   },
   
   "web_accessible_resources": [

--- a/momentum-ambient.js
+++ b/momentum-ambient.js
@@ -1,0 +1,185 @@
+(function exposeMomentumAmbient(globalObject) {
+    'use strict';
+
+    const NATIVE_HOST = 'com.allinstride.momentum.novatab';
+    const CACHE_KEY = 'momentumAmbientLastGoodV1';
+    const MAX_RESPONSE_BYTES = 16_384;
+    const FETCH_TIMEOUT_MILLISECONDS = 5_000;
+    const LAST_GOOD_MILLISECONDS = 24 * 60 * 60 * 1000;
+    const AMBIENT_KEYS = ['cacheState', 'fetchedAt', 'pulsePendingCount', 'schemaVersion', 'tasks'];
+    const TASK_KEYS = ['dueDate', 'id', 'name', 'priority'];
+    const GRANT_KEYS = ['capability', 'endpoint', 'expiresAt', 'schemaVersion'];
+
+    function parseAmbientPayload(value) {
+        if (!plainRecord(value) || !exactKeys(value, AMBIENT_KEYS) || value.schemaVersion !== 1) invalidPayload();
+        if (value.cacheState !== 'live' && value.cacheState !== 'stale') invalidPayload();
+        if (!validTimestamp(value.fetchedAt)) invalidPayload();
+        if (!Number.isSafeInteger(value.pulsePendingCount) || value.pulsePendingCount < 0) invalidPayload();
+        if (!Array.isArray(value.tasks) || value.tasks.length > 3) invalidPayload();
+        const tasks = value.tasks.map((task) => {
+            if (!plainRecord(task) || !exactKeys(task, TASK_KEYS)) invalidPayload();
+            if (!boundedString(task.id, 128) || !boundedString(task.name, 500)) invalidPayload();
+            if (!['P0', 'P1', 'P2', 'P3'].includes(task.priority)) invalidPayload();
+            if (task.dueDate !== null && (typeof task.dueDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(task.dueDate))) invalidPayload();
+            return task;
+        });
+        return { schemaVersion: 1, cacheState: value.cacheState, fetchedAt: value.fetchedAt, tasks, pulsePendingCount: value.pulsePendingCount };
+    }
+
+    function parseNativeGrant(value) {
+        if (!plainRecord(value) || !exactKeys(value, GRANT_KEYS) || value.schemaVersion !== 1) invalidGrant();
+        if (typeof value.endpoint !== 'string' || !/^http:\/\/127\.0\.0\.1:[1-9]\d{0,4}\/v1\/ambient$/.test(value.endpoint)) invalidGrant();
+        const url = new URL(value.endpoint);
+        const port = Number(url.port);
+        if (!Number.isInteger(port) || port < 1 || port > 65535) invalidGrant();
+        if (typeof value.capability !== 'string' || !/^[A-Za-z0-9_-]{43}$/.test(value.capability)) invalidGrant();
+        if (!validTimestamp(value.expiresAt)) invalidGrant();
+        return value;
+    }
+
+    function resolveAmbientState(live, cached, now = new Date()) {
+        try {
+            if (live !== null) {
+                const payload = parseAmbientPayload(live);
+                return { kind: payload.cacheState === 'live' ? 'live' : 'cached', payload };
+            }
+        } catch (_) { /* independently validate cache */ }
+        try {
+            const payload = parseAmbientPayload(cached);
+            const age = now.getTime() - Date.parse(payload.fetchedAt);
+            if (Number.isFinite(age) && age >= 0 && age <= LAST_GOOD_MILLISECONDS) return { kind: 'cached', payload };
+        } catch (_) { /* unavailable */ }
+        return { kind: 'unavailable' };
+    }
+
+    async function loadAmbient(chromeApi, fetchImpl, now = new Date()) {
+        const controller = new AbortController();
+        const deadline = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MILLISECONDS);
+        try {
+            const grant = parseNativeGrant(await chromeApi.runtime.sendNativeMessage(
+                NATIVE_HOST,
+                { schemaVersion: 1, action: 'grant' },
+            ));
+            if (Date.parse(grant.expiresAt) <= now.getTime()) throw new Error('ambient_unavailable');
+            const response = await fetchImpl(grant.endpoint, {
+                method: 'GET',
+                headers: { 'X-Momentum-Capability': grant.capability },
+                cache: 'no-store',
+                credentials: 'omit',
+                redirect: 'error',
+                referrerPolicy: 'no-referrer',
+                signal: controller.signal,
+            });
+            if (!response.ok || response.status !== 200 || response.headers.get('content-type')?.split(';')[0].trim() !== 'application/json') {
+                throw new Error('ambient_unavailable');
+            }
+            const text = await readBoundedUtf8(response, MAX_RESPONSE_BYTES);
+            const payload = parseAmbientPayload(JSON.parse(text));
+            await chromeApi.storage.local.set({ [CACHE_KEY]: payload });
+            return { kind: payload.cacheState === 'live' ? 'live' : 'cached', payload };
+        } catch (_) {
+            try {
+                const stored = await chromeApi.storage.local.get(CACHE_KEY);
+                return resolveAmbientState(null, stored[CACHE_KEY] ?? null, now);
+            } catch (_) {
+                return { kind: 'unavailable' };
+            }
+        } finally {
+            clearTimeout(deadline);
+        }
+    }
+
+    async function readBoundedUtf8(response, maximumBytes) {
+        const reader = response.body?.getReader?.();
+        if (!reader) throw new Error('ambient_unavailable');
+        const chunks = [];
+        let length = 0;
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (!(value instanceof Uint8Array)) throw new Error('ambient_unavailable');
+                length += value.byteLength;
+                if (length > maximumBytes) throw new Error('ambient_unavailable');
+                chunks.push(value);
+            }
+        } catch (error) {
+            try { await reader.cancel(); } catch (_) { /* bounded failure */ }
+            throw error;
+        }
+        const bytes = new Uint8Array(length);
+        let offset = 0;
+        for (const chunk of chunks) {
+            bytes.set(chunk, offset);
+            offset += chunk.byteLength;
+        }
+        return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    }
+
+    function renderAmbient(container, state) {
+        while (container.firstChild) container.removeChild(container.firstChild);
+        const heading = document.createElement('div');
+        heading.className = 'momentum-ambient-heading';
+        const title = document.createElement('h2');
+        title.textContent = 'Momentum';
+        const badge = document.createElement('span');
+        badge.className = `momentum-ambient-badge ${state.kind}`;
+        badge.textContent = state.kind === 'live' ? 'Live' : state.kind === 'cached' ? 'Last good' : 'Unavailable';
+        heading.append(title, badge);
+        container.appendChild(heading);
+        if (state.kind === 'unavailable') {
+            const message = document.createElement('p');
+            message.className = 'momentum-ambient-unavailable';
+            message.textContent = 'Momentum is unavailable. Open Momentum Command to reconnect.';
+            container.appendChild(message);
+            return;
+        }
+        const summary = document.createElement('p');
+        summary.className = 'momentum-ambient-pulse';
+        summary.textContent = `${state.payload.pulsePendingCount} Pulse item${state.payload.pulsePendingCount === 1 ? '' : 's'} pending`;
+        container.appendChild(summary);
+        const list = document.createElement('ol');
+        list.className = 'momentum-ambient-tasks';
+        for (const task of state.payload.tasks) {
+            const item = document.createElement('li');
+            const priority = document.createElement('span');
+            priority.className = `momentum-priority ${task.priority.toLowerCase()}`;
+            priority.textContent = task.priority;
+            const name = document.createElement('span');
+            name.textContent = task.name;
+            item.append(priority, name);
+            list.appendChild(item);
+        }
+        container.appendChild(list);
+    }
+
+    async function start() {
+        const container = document.getElementById('momentum-ambient');
+        if (!container) return;
+        renderAmbient(container, await loadAmbient(chrome, fetch));
+    }
+
+    function plainRecord(value) {
+        return value !== null && typeof value === 'object' && !Array.isArray(value)
+            && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
+    }
+    function exactKeys(value, expected) {
+        const keys = Object.keys(value).sort();
+        return keys.length === expected.length && keys.every((key, index) => key === expected[index]);
+    }
+    function boundedString(value, maximumBytes) {
+        return typeof value === 'string' && value.length > 0 && value.trim() === value
+            && new TextEncoder().encode(value).length <= maximumBytes && !/[\u0000-\u001f\u007f]/.test(value);
+    }
+    function validTimestamp(value) {
+        return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value)
+            && Number.isFinite(Date.parse(value));
+    }
+    function invalidPayload() { throw new Error('invalid_ambient_payload'); }
+    function invalidGrant() { throw new Error('invalid_native_grant'); }
+
+    const api = { CACHE_KEY, loadAmbient, parseAmbientPayload, parseNativeGrant, renderAmbient, resolveAmbientState };
+    globalObject.MomentumAmbient = api;
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', start);
+}(typeof globalThis === 'undefined' ? this : globalThis));

--- a/momentum-bridge.json
+++ b/momentum-bridge.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "extensionId": "hldcbbiabmeilbmcgeaecmkmhmllagcg",
+  "callerOrigin": "chrome-extension://hldcbbiabmeilbmcgeaecmkmhmllagcg",
+  "nativeHostName": "com.allinstride.momentum.novatab",
+  "nativeHostPath": "/Applications/Momentum Command.app/Contents/MacOS/momentum-command-native-host",
+  "nativeHostRequirement": "identifier \"com.allinstride.momentum.command.native-host\"",
+  "browserAssetSha256": "35b6a984f5faf0c08b566aca58b5d7c276df1055fac7f05448647dc865bcb774"
+}

--- a/new_tab.css
+++ b/new_tab.css
@@ -94,6 +94,75 @@ body {
     margin: 0 auto;
 }
 
+.momentum-ambient {
+    width: 100%;
+    margin: 0 0 24px;
+    padding: 18px 20px;
+    border: 1px solid rgba(255, 255, 255, 0.65);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+    box-shadow: 0 8px 30px rgba(45, 55, 72, 0.06);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+}
+
+.momentum-ambient-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.momentum-ambient-heading h2 {
+    margin: 0;
+    color: var(--secondary-color);
+    font-size: 18px;
+    letter-spacing: -0.02em;
+}
+
+.momentum-ambient-badge {
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    background: #e8edf3;
+    color: #526070;
+}
+
+.momentum-ambient-badge.live { background: #ddf7e8; color: #196c3a; }
+.momentum-ambient-badge.cached { background: #fff2cf; color: #805b00; }
+.momentum-ambient-pulse,
+.momentum-ambient-unavailable { margin: 8px 0 0; color: #647184; font-size: 13px; }
+
+.momentum-ambient-tasks {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    margin: 14px 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.momentum-ambient-tasks li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: rgba(245, 247, 250, 0.9);
+    color: var(--text-color);
+    font-size: 13px;
+}
+
+.momentum-priority { flex: 0 0 auto; font-size: 10px; font-weight: 700; color: #566273; }
+.momentum-priority.p0 { color: #a32626; }
+.momentum-priority.p1 { color: #9a5d00; }
+
+@media (max-width: 760px) {
+    .momentum-ambient-tasks { grid-template-columns: 1fr; }
+}
+
 /* Categories container with improved grid */
 #categories-container {
     width: 100%;

--- a/new_tab.html
+++ b/new_tab.html
@@ -9,6 +9,9 @@
 </head>
 <body>
     <div id="main-content-wrapper">
+        <section id="momentum-ambient" class="momentum-ambient" aria-live="polite" aria-label="Momentum priorities">
+            <p class="momentum-ambient-unavailable">Loading Momentum…</p>
+        </section>
         <div id="categories-container">
         </div>
     </div>
@@ -62,6 +65,7 @@
     <script src="constants-messages.js"></script>
     <script src="utils.js"></script>
     <script src="storage-utils-extended.js"></script>
+    <script src="momentum-ambient.js"></script>
     <script src="new_tab.js"></script>
 </body>
 </html>

--- a/test/MomentumAmbient.test.js
+++ b/test/MomentumAmbient.test.js
@@ -1,0 +1,188 @@
+const {
+  CACHE_KEY,
+  loadAmbient,
+  parseAmbientPayload,
+  parseNativeGrant,
+  resolveAmbientState,
+} = require('../momentum-ambient.js');
+
+const live = {
+  schemaVersion: 1,
+  cacheState: 'live',
+  fetchedAt: '2026-08-14T08:00:00.000Z',
+  tasks: [
+    { id: 'one', name: 'First', priority: 'P0', dueDate: null },
+    { id: 'two', name: 'Second', priority: 'P1', dueDate: '2026-08-15' },
+  ],
+  pulsePendingCount: 3,
+};
+
+test('shipped browser asset is bound to the exact Momentum bridge contract', () => {
+  const root = resolve(__dirname, '..');
+  const asset = readFileSync(resolve(root, 'momentum-ambient.js'));
+  const contract = JSON.parse(readFileSync(resolve(root, 'momentum-bridge.json'), 'utf8'));
+  expect(Object.keys(contract).sort()).toEqual([
+    'browserAssetSha256',
+    'callerOrigin',
+    'extensionId',
+    'nativeHostName',
+    'nativeHostPath',
+    'nativeHostRequirement',
+    'schemaVersion',
+  ]);
+  expect(contract.schemaVersion).toBe(1);
+  expect(contract.extensionId).toBe('hldcbbiabmeilbmcgeaecmkmhmllagcg');
+  expect(createHash('sha256').update(asset).digest('hex')).toBe(contract.browserAssetSha256);
+});
+
+test('strictly validates the minimal payload and IPv4-only one-shot grant', () => {
+  expect(parseAmbientPayload(JSON.parse(JSON.stringify(live)))).toEqual(live);
+  expect(() => parseAmbientPayload({ ...live, token: 'no' })).toThrow('invalid_ambient_payload');
+  expect(() => parseAmbientPayload({ ...live, tasks: [live.tasks[0], live.tasks[0], live.tasks[0], live.tasks[0]] })).toThrow('invalid_ambient_payload');
+
+  const grant = {
+    schemaVersion: 1,
+    endpoint: 'http://127.0.0.1:43123/v1/ambient',
+    capability: 'a'.repeat(43),
+    expiresAt: '2026-08-14T08:15:00.000Z',
+  };
+  expect(parseNativeGrant(grant)).toEqual(grant);
+  for (const endpoint of [
+    'http://localhost:43123/v1/ambient',
+    'http://[::1]:43123/v1/ambient',
+    'https://127.0.0.1:43123/v1/ambient',
+  ]) expect(() => parseNativeGrant({ ...grant, endpoint })).toThrow('invalid_native_grant');
+});
+
+test('fetches live through native messaging without persisting the grant', async () => {
+  const storage = {};
+  const chromeApi = {
+    runtime: {
+      sendNativeMessage: jest.fn().mockResolvedValue({
+        schemaVersion: 1,
+        endpoint: 'http://127.0.0.1:43123/v1/ambient',
+        capability: 'a'.repeat(43),
+        expiresAt: '2026-08-14T08:15:00.000Z',
+      }),
+    },
+    storage: { local: {
+      get: jest.fn().mockResolvedValue(storage),
+      set: jest.fn(async (value) => Object.assign(storage, value)),
+    } },
+  };
+  const fetchImpl = jest.fn().mockResolvedValue(streamingResponse(JSON.stringify(live)));
+  await expect(loadAmbient(chromeApi, fetchImpl, new Date('2026-08-14T08:01:00Z'))).resolves.toEqual({ kind: 'live', payload: live });
+  expect(chromeApi.runtime.sendNativeMessage).toHaveBeenCalledWith(
+    'com.allinstride.momentum.novatab',
+    { schemaVersion: 1, action: 'grant' },
+  );
+  expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:43123/v1/ambient', expect.objectContaining({
+    method: 'GET',
+    headers: { 'X-Momentum-Capability': 'a'.repeat(43) },
+    credentials: 'omit',
+    redirect: 'error',
+  }));
+  expect(storage).toEqual({ [CACHE_KEY]: live });
+  expect(JSON.stringify(storage)).not.toMatch(/capability|endpoint|authorization|bearer/i);
+});
+
+test('labels a fetched stale payload as cached', async () => {
+  const stale = { ...live, cacheState: 'stale' };
+  const chromeApi = chromeForGrant();
+  await expect(loadAmbient(
+    chromeApi,
+    jest.fn().mockResolvedValue(streamingResponse(JSON.stringify(stale))),
+    new Date('2026-08-14T08:01:00Z'),
+  )).resolves.toEqual({ kind: 'cached', payload: stale });
+});
+
+test('aborts a hanging fetch and bounds the response stream before full buffering', async () => {
+  jest.useFakeTimers();
+  try {
+    const chromeApi = chromeForGrant();
+    const hangingFetch = jest.fn((_url, options) => new Promise((_resolve, reject) => {
+      options.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    }));
+    const pending = loadAmbient(chromeApi, hangingFetch, new Date('2026-08-14T08:01:00Z'));
+    await jest.advanceTimersByTimeAsync(5_001);
+    await expect(pending).resolves.toEqual({ kind: 'unavailable' });
+
+    const oversized = new Uint8Array(16_385).fill(120);
+    await expect(loadAmbient(
+      chromeApi,
+      jest.fn().mockResolvedValue(streamingResponse(oversized)),
+      new Date('2026-08-14T08:01:00Z'),
+    )).resolves.toEqual({ kind: 'unavailable' });
+  } finally {
+    jest.useRealTimers();
+  }
+});
+
+test('uses a bounded last-good payload offline and never renders expired cache', async () => {
+  expect(resolveAmbientState(null, { ...live, cacheState: 'stale' }, new Date('2026-08-15T07:59:59Z'))).toEqual({
+    kind: 'cached', payload: { ...live, cacheState: 'stale' },
+  });
+  expect(resolveAmbientState(null, live, new Date('2026-08-15T08:00:01Z'))).toEqual({ kind: 'unavailable' });
+
+  const chromeApi = {
+    runtime: { sendNativeMessage: jest.fn().mockRejectedValue(new Error('host absent')) },
+    storage: { local: {
+      get: jest.fn().mockResolvedValue({ [CACHE_KEY]: live }),
+      set: jest.fn(),
+    } },
+  };
+  await expect(loadAmbient(chromeApi, jest.fn(), new Date('2026-08-14T09:00:00Z'))).resolves.toEqual({
+    kind: 'cached', payload: live,
+  });
+  expect(chromeApi.storage.local.set).not.toHaveBeenCalled();
+});
+
+test('rejects oversized, non-JSON, or redirected loopback responses without leaking details', async () => {
+  const grant = {
+    schemaVersion: 1,
+    endpoint: 'http://127.0.0.1:43123/v1/ambient',
+    capability: 'a'.repeat(43),
+    expiresAt: '2026-08-14T08:15:00.000Z',
+  };
+  const chromeApi = {
+    runtime: { sendNativeMessage: jest.fn().mockResolvedValue(grant) },
+    storage: { local: { get: jest.fn().mockResolvedValue({}), set: jest.fn() } },
+  };
+  for (const response of [
+    streamingResponse('{}', { contentType: 'text/html' }),
+    streamingResponse('x'.repeat(16_385)),
+    streamingResponse(new Uint8Array([0xff])),
+    streamingResponse('{}', { status: 302 }),
+  ]) {
+    await expect(loadAmbient(chromeApi, jest.fn().mockResolvedValue(response), new Date())).resolves.toEqual({ kind: 'unavailable' });
+  }
+});
+
+function chromeForGrant() {
+  return {
+    runtime: { sendNativeMessage: jest.fn().mockResolvedValue({
+      schemaVersion: 1,
+      endpoint: 'http://127.0.0.1:43123/v1/ambient',
+      capability: 'a'.repeat(43),
+      expiresAt: '2026-08-14T08:15:00.000Z',
+    }) },
+    storage: { local: { get: jest.fn().mockResolvedValue({}), set: jest.fn() } },
+  };
+}
+
+function streamingResponse(value, { contentType = 'application/json', status = 200 } = {}) {
+  const bytes = value instanceof Uint8Array ? value : new TextEncoder().encode(value);
+  let delivered = false;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => contentType },
+    body: { getReader: () => ({
+      read: async () => delivered ? { done: true } : (delivered = true, { done: false, value: bytes }),
+      cancel: async () => {},
+    }) },
+  };
+}
+const { createHash } = require('node:crypto');
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');


### PR DESCRIPTION
## Summary
- add the strict Momentum native-messaging and loopback ambient briefing client
- render live/cached status and bounded open-task/Pulse summaries without exposing API credentials
- bind the shipped browser asset and Command descriptor byte-for-byte and add locked CI coverage

## Verification
- Jest: 110/110
- Momentum canonical browser asset and descriptor are byte-identical
- independent read-only security/spec review: APPROVE

Installation remains rollback-gated until the Command companion PR merges and exact-main CI passes.