### PR TITLE
fix: normalize Momentum loopback headers

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
   "permissions": [
     "storage",
     "bookmarks",
-    "nativeMessaging"
+    "nativeMessaging",
+    "declarativeNetRequestWithHostAccess"
   ],
   
   "host_permissions": [
@@ -46,6 +47,16 @@
   "background": {
     "service_worker": "background.js"
   },
+
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "momentum_loopback",
+        "enabled": true,
+        "path": "momentum-loopback-rules.json"
+      }
+    ]
+  },
   
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'; connect-src https://www.google.com/ http://127.0.0.1:*;"
@@ -62,5 +73,5 @@
     }
   ],
   
-  "minimum_chrome_version": "88"
+  "minimum_chrome_version": "101"
 }

--- a/momentum-loopback-rules.json
+++ b/momentum-loopback-rules.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+          "header": "DNT",
+          "operation": "remove"
+        },
+        {
+          "header": "Origin",
+          "operation": "set",
+          "value": "chrome-extension://hldcbbiabmeilbmcgeaecmkmhmllagcg"
+        }
+      ]
+    },
+    "condition": {
+      "regexFilter": "^http://127\\.0\\.0\\.1:[0-9]+/v1/ambient$",
+      "initiatorDomains": [
+        "hldcbbiabmeilbmcgeaecmkmhmllagcg"
+      ],
+      "resourceTypes": [
+        "xmlhttprequest"
+      ]
+    }
+  }
+]

--- a/test/MomentumAmbient.test.js
+++ b/test/MomentumAmbient.test.js
@@ -35,6 +35,41 @@ test('shipped browser asset is bound to the exact Momentum bridge contract', () 
   expect(createHash('sha256').update(asset).digest('hex')).toBe(contract.browserAssetSha256);
 });
 
+test('normalizes only Chrome compatibility headers on the fixed Momentum loopback request', () => {
+  const root = resolve(__dirname, '..');
+  const manifest = JSON.parse(readFileSync(resolve(root, 'manifest.json'), 'utf8'));
+  const rules = JSON.parse(readFileSync(resolve(root, 'momentum-loopback-rules.json'), 'utf8'));
+
+  expect(manifest.permissions).toContain('declarativeNetRequestWithHostAccess');
+  expect(manifest.declarative_net_request).toEqual({
+    rule_resources: [{
+      id: 'momentum_loopback',
+      enabled: true,
+      path: 'momentum-loopback-rules.json',
+    }],
+  });
+  expect(rules).toEqual([{
+    id: 1,
+    priority: 1,
+    action: {
+      type: 'modifyHeaders',
+      requestHeaders: [
+        { header: 'DNT', operation: 'remove' },
+        {
+          header: 'Origin',
+          operation: 'set',
+          value: 'chrome-extension://hldcbbiabmeilbmcgeaecmkmhmllagcg',
+        },
+      ],
+    },
+    condition: {
+      regexFilter: '^http://127\\.0\\.0\\.1:[0-9]+/v1/ambient$',
+      initiatorDomains: ['hldcbbiabmeilbmcgeaecmkmhmllagcg'],
+      resourceTypes: ['xmlhttprequest'],
+    },
+  }]);
+});
+
 test('strictly validates the minimal payload and IPv4-only one-shot grant', () => {
   expect(parseAmbientPayload(JSON.parse(JSON.stringify(live)))).toEqual(live);
   expect(() => parseAmbientPayload({ ...live, token: 'no' })).toThrow('invalid_ambient_payload');


### PR DESCRIPTION
## Summary
- normalize the exact Chrome 151 loopback request by removing DNT and setting the fixed NovaTab extension Origin
- scope the static rule to the exact IPv4 Momentum ambient URL, extension initiator, and XHR resource type
- lock the manifest and rule contract with Jest coverage

## Verification
- `pnpm exec jest --runInBand` (111 passed)
- JSON parse and `git diff --check`
- live fresh-tab witness: Live, 20 Pulse pending, exact three projected P0 tasks
- offline witness: Last good after Command stop; fresh Live after restart